### PR TITLE
Fix _ma_mark_page_with_transid macro

### DIFF
--- a/storage/maria/maria_def.h
+++ b/storage/maria/maria_def.h
@@ -761,9 +761,11 @@ struct st_maria_handler
 #define _ma_korr_transid(buff) \
   transid_korr((buff) + LSN_STORE_SIZE)
 #define _ma_store_keypage_flag(share,x,flag) x[(share)->keypage_header - KEYPAGE_USED_SIZE - KEYPAGE_FLAG_SIZE]= (flag)
-#define _ma_mark_page_with_transid(share, page) \
-  (page)->flag|= KEYPAGE_FLAG_HAS_TRANSID;                              \
-  (page)->buff[(share)->keypage_header - KEYPAGE_USED_SIZE - KEYPAGE_FLAG_SIZE]= (page)->flag;
+#define _ma_mark_page_with_transid(share, page)                                                  \
+  do {                                                                                           \
+    (page)->flag|= KEYPAGE_FLAG_HAS_TRANSID;                                                     \
+    (page)->buff[(share)->keypage_header - KEYPAGE_USED_SIZE - KEYPAGE_FLAG_SIZE]= (page)->flag; \
+  } while (0)
 
 #define KEYPAGE_KEY_VERSION(share, x) ((x) + \
                                        (share)->keypage_header -        \


### PR DESCRIPTION
Fix macro to be safe in single line else statements.  This is a real issue that can be seen in two different usages of the macro in storage/maria/ma_delete.c
